### PR TITLE
Prevent users from spamming the join button

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,1 +1,8 @@
 export const IMPOSTOR_BACKEND_PORT = 22044;
+
+/**
+ * Defines the minimum amount of time a client needs to wait before it can try connecting again.
+ *
+ * Time is in milliseconds
+ */
+export const JOIN_TIMEOUT = 5000;


### PR DESCRIPTION
This adds a server side timeout that prevents users from switching to a
different room within 5 seconds. Some regions (cough Asia cough) just
takes a while longer to join. As there is still a use case for rejoining
the underlying issue (that the room is destroyed before it is rejoined)
is not fixed.